### PR TITLE
Handle function-like macros when parsing C defines

### DIFF
--- a/include/core/parseutil.h
+++ b/include/core/parseutil.h
@@ -112,10 +112,17 @@ private:
     QHash<QString, int> globalDefineValues;
     QHash<QString, QString> globalDefineExpressions;
 
+    struct FunctionMacro {
+        QStringList params;
+        QString expression;
+    };
+    QHash<QString, FunctionMacro> knownFunctionMacros;
+
     bool updatesSplashScreen = false;
 
     int evaluateDefine(const QString &identifier, bool *ok = nullptr);
     int evaluateExpression(const QString &expression);
+    QString expandMacros(QString expression);
     QList<Token> tokenizeExpression(QString expression);
     QList<Token> generatePostfix(const QList<Token> &tokens);
     int evaluatePostfix(const QList<Token> &postfix);


### PR DESCRIPTION
## Summary
- support single-argument function macros in C define parser
- expand macro invocations in expressions and clear macros on reset
- strip unsigned/long suffixes from integer literals when tokenizing expressions
- ignore preprocessor directives in enum bodies to avoid treating directives as enum entries

## Testing
- `apt-get update`
- `qmake tests/tests.pro`
- `make`
- `QT_QPA_PLATFORM=offscreen ./test_am95_importer`


------
https://chatgpt.com/codex/tasks/task_e_68a8e4ec9d008323813f275735feb5e3